### PR TITLE
[BUGFIX] Broken wizard icon in user settings

### DIFF
--- a/Classes/OpenidModuleSetup.php
+++ b/Classes/OpenidModuleSetup.php
@@ -59,7 +59,7 @@ class OpenidModuleSetup
                 'vHWin=window.open(' . $popUpUrl . ',null,\'width=800,height=600,status=0,menubar=0,scrollbars=0\');' .
                 'vHWin.focus();return false;' .
                 '">' .
-                    '<img src="../typo3/sysext/openid/ext_icon_small.png" alt="' . $add . '" title="' . $add . '"/>' .
+                    '<img src="../typo3conf/ext/openid/ext_icon_small.png" alt="' . $add . '" title="' . $add . '"/>' .
                 '</a>' .
             '</div>' .
             '</div>';


### PR DESCRIPTION
Since the openid extension has been externalized from TYPO3 Core,
the path to the wizard icon needs to be adapted.

Resolves: #11
