### PR TITLE
Update the php-openid library

### DIFF
--- a/lib/php-openid/Auth/OpenID/AX.php
+++ b/lib/php-openid/Auth/OpenID/AX.php
@@ -69,7 +69,7 @@ function Auth_OpenID_AX_checkAlias($alias)
  * @package OpenID
  */
 class Auth_OpenID_AX_Error {
-    function Auth_OpenID_AX_Error($message=null)
+    function __construct($message=null)
     {
         $this->message = $message;
     }
@@ -151,7 +151,7 @@ class Auth_OpenID_AX_AttrInfo {
      * @param string $alias The name that should be given to this
      * attribute in the request.
      */
-    function Auth_OpenID_AX_AttrInfo($type_uri, $count, $required,
+    function __construct($type_uri, $count, $required,
                                      $alias)
     {
         /**
@@ -269,7 +269,7 @@ class Auth_OpenID_AX_FetchRequest extends Auth_OpenID_AX_Message {
 
     var $mode = 'fetch_request';
 
-    function Auth_OpenID_AX_FetchRequest($update_url=null)
+    function __construct($update_url=null)
     {
         /**
          * requested_attributes: The attributes that have been
@@ -540,7 +540,7 @@ class Auth_OpenID_AX_FetchRequest extends Auth_OpenID_AX_Message {
  */
 class Auth_OpenID_AX_KeyValueMessage extends Auth_OpenID_AX_Message {
 
-    function Auth_OpenID_AX_KeyValueMessage()
+    function __construct()
     {
         $this->data = array();
     }
@@ -793,9 +793,9 @@ class Auth_OpenID_AX_KeyValueMessage extends Auth_OpenID_AX_Message {
 class Auth_OpenID_AX_FetchResponse extends Auth_OpenID_AX_KeyValueMessage {
     var $mode = 'fetch_response';
 
-    function Auth_OpenID_AX_FetchResponse($update_url=null)
+    function __construct($update_url=null)
     {
-        $this->Auth_OpenID_AX_KeyValueMessage();
+        parent::__construct();
         $this->update_url = $update_url;
     }
 
@@ -990,7 +990,7 @@ class Auth_OpenID_AX_StoreResponse extends Auth_OpenID_AX_Message {
         return new Auth_OpenID_AX_StoreResponse($succeeded, $error_message);
     }
 
-    function Auth_OpenID_AX_StoreResponse($succeeded=true, $error_message=null)
+    function __construct($succeeded=true, $error_message=null)
     {
         if ($succeeded) {
             $this->mode = $this->SUCCESS_MODE;

--- a/lib/php-openid/Auth/OpenID/Association.php
+++ b/lib/php-openid/Auth/OpenID/Association.php
@@ -128,7 +128,7 @@ class Auth_OpenID_Association {
      * this time is 'HMAC-SHA1' and 'HMAC-SHA256', but new types may
      * be defined in the future.
      */
-    function Auth_OpenID_Association(
+    function __construct(
         $handle, $secret, $issued, $lifetime, $assoc_type)
     {
         if (!in_array($assoc_type,
@@ -523,7 +523,7 @@ function Auth_OpenID_getEncryptedNegotiator()
  * @package OpenID
  */
 class Auth_OpenID_SessionNegotiator {
-    function Auth_OpenID_SessionNegotiator($allowed_types)
+    function __construct($allowed_types)
     {
         $this->allowed_types = array();
         $this->setAllowedTypes($allowed_types);

--- a/lib/php-openid/Auth/OpenID/Consumer.php
+++ b/lib/php-openid/Auth/OpenID/Consumer.php
@@ -258,7 +258,7 @@ class Auth_OpenID_Consumer {
      * when creating the internal consumer object.  This is used for
      * testing.
      */
-    function Auth_OpenID_Consumer($store, $session = null,
+    function __construct($store, $session = null,
                                   $consumer_cls = null)
     {
         if ($session === null) {
@@ -456,7 +456,7 @@ class Auth_OpenID_DiffieHellmanSHA1ConsumerSession {
     var $secret_size = 20;
     var $allowed_assoc_types = array('HMAC-SHA1');
 
-    function Auth_OpenID_DiffieHellmanSHA1ConsumerSession($dh = null)
+    function __construct($dh = null)
     {
         if ($dh === null) {
             $dh = new Auth_OpenID_DiffieHellman();
@@ -611,7 +611,7 @@ class Auth_OpenID_GenericConsumer {
      * in the module description.  The default value is False, which
      * disables immediate mode.
      */
-    function Auth_OpenID_GenericConsumer($store)
+    function __construct($store)
     {
         $this->store = $store;
         $this->negotiator = Auth_OpenID_getDefaultNegotiator();
@@ -1757,7 +1757,7 @@ class Auth_OpenID_AuthRequest {
      * class.  Instances of this class are created by the library when
      * needed.
      */
-    function Auth_OpenID_AuthRequest($endpoint, $assoc)
+    function __construct($endpoint, $assoc)
     {
         $this->assoc = $assoc;
         $this->endpoint = $endpoint;
@@ -2036,7 +2036,7 @@ class Auth_OpenID_SuccessResponse extends Auth_OpenID_ConsumerResponse {
     /**
      * @access private
      */
-    function Auth_OpenID_SuccessResponse($endpoint, $message, $signed_args=null)
+    function __construct($endpoint, $message, $signed_args=null)
     {
         $this->endpoint = $endpoint;
         $this->identity_url = $endpoint->claimed_id;
@@ -2139,7 +2139,7 @@ class Auth_OpenID_SuccessResponse extends Auth_OpenID_ConsumerResponse {
 class Auth_OpenID_FailureResponse extends Auth_OpenID_ConsumerResponse {
     var $status = Auth_OpenID_FAILURE;
 
-    function Auth_OpenID_FailureResponse($endpoint, $message = null,
+    function __construct($endpoint, $message = null,
                                          $contact = null, $reference = null)
     {
         $this->setEndpoint($endpoint);
@@ -2164,7 +2164,7 @@ class Auth_OpenID_TypeURIMismatch extends Auth_OpenID_FailureResponse {
  * @package OpenID
  */
 class Auth_OpenID_ServerErrorContainer {
-    function Auth_OpenID_ServerErrorContainer($error_text,
+    function __construct($error_text,
                                               $error_code,
                                               $message)
     {
@@ -2202,7 +2202,7 @@ class Auth_OpenID_ServerErrorContainer {
 class Auth_OpenID_CancelResponse extends Auth_OpenID_ConsumerResponse {
     var $status = Auth_OpenID_CANCEL;
 
-    function Auth_OpenID_CancelResponse($endpoint)
+    function __construct($endpoint)
     {
         $this->setEndpoint($endpoint);
     }
@@ -2228,7 +2228,7 @@ class Auth_OpenID_CancelResponse extends Auth_OpenID_ConsumerResponse {
 class Auth_OpenID_SetupNeededResponse extends Auth_OpenID_ConsumerResponse {
     var $status = Auth_OpenID_SETUP_NEEDED;
 
-    function Auth_OpenID_SetupNeededResponse($endpoint,
+    function __construct($endpoint,
                                              $setup_url = null)
     {
         $this->setEndpoint($endpoint);

--- a/lib/php-openid/Auth/OpenID/DiffieHellman.php
+++ b/lib/php-openid/Auth/OpenID/DiffieHellman.php
@@ -47,7 +47,7 @@ class Auth_OpenID_DiffieHellman {
     var $private;
     var $lib = null;
 
-    function Auth_OpenID_DiffieHellman($mod = null, $gen = null,
+    function __construct($mod = null, $gen = null,
                                        $private = null, $lib = null)
     {
         if ($lib === null) {

--- a/lib/php-openid/Auth/OpenID/Discover.php
+++ b/lib/php-openid/Auth/OpenID/Discover.php
@@ -62,7 +62,7 @@ function Auth_OpenID_getOpenIDTypeName($type_uri) {
  * Object representing an OpenID service endpoint.
  */
 class Auth_OpenID_ServiceEndpoint {
-    function Auth_OpenID_ServiceEndpoint()
+    function __construct()
     {
         $this->claimed_id = null;
         $this->server_url = null;

--- a/lib/php-openid/Auth/OpenID/DumbStore.php
+++ b/lib/php-openid/Auth/OpenID/DumbStore.php
@@ -50,7 +50,7 @@ class Auth_OpenID_DumbStore extends Auth_OpenID_OpenIDStore {
      * @param string secret_phrase The phrase used to create the auth
      * key returned by getAuthKey
      */
-    function Auth_OpenID_DumbStore($secret_phrase)
+    function __construct($secret_phrase)
     {
         $this->auth_key = Auth_OpenID_SHA1($secret_phrase);
     }

--- a/lib/php-openid/Auth/OpenID/FileStore.php
+++ b/lib/php-openid/Auth/OpenID/FileStore.php
@@ -46,7 +46,7 @@ class Auth_OpenID_FileStore extends Auth_OpenID_OpenIDStore {
      * @param string $directory This is the directory to put the store
      * directories in.
      */
-    function Auth_OpenID_FileStore($directory)
+    function __construct($directory)
     {
         if (!Auth_OpenID::ensureDir($directory)) {
             trigger_error('Not a directory and failed to create: '
@@ -482,7 +482,7 @@ class Auth_OpenID_FileStore extends Auth_OpenID_OpenIDStore {
         }
 
         if ($handle = opendir($dir)) {
-            while ($item = readdir($handle)) {
+            while (false !== ($item = readdir($handle))) {
                 if (!in_array($item, array('.', '..'))) {
                     if (is_dir($dir . $item)) {
 

--- a/lib/php-openid/Auth/OpenID/MDB2Store.php
+++ b/lib/php-openid/Auth/OpenID/MDB2Store.php
@@ -62,7 +62,7 @@ class Auth_OpenID_MDB2Store extends Auth_OpenID_OpenIDStore {
      * the name of the table used for storing nonces.  The default
      * value is 'oid_nonces'.
      */
-    function Auth_OpenID_MDB2Store($connection,
+    function __construct($connection,
                                   $associations_table = null,
                                   $nonces_table = null)
     {

--- a/lib/php-openid/Auth/OpenID/MemcachedStore.php
+++ b/lib/php-openid/Auth/OpenID/MemcachedStore.php
@@ -41,7 +41,7 @@ class Auth_OpenID_MemcachedStore extends Auth_OpenID_OpenIDStore {
      *
      * @param resource connection Memcache connection resourse
      */
-    function Auth_OpenID_MemcachedStore($connection, $compress = false)
+    function __construct($connection, $compress = false)
     {
         $this->connection = $connection;
         $this->compress = $compress ? MEMCACHE_COMPRESSED : 0;

--- a/lib/php-openid/Auth/OpenID/Message.php
+++ b/lib/php-openid/Auth/OpenID/Message.php
@@ -127,7 +127,7 @@ class Auth_OpenID_Mapping {
      * Initialize a mapping.  If $classic_array is specified, its keys
      * and values are used to populate the mapping.
      */
-    function Auth_OpenID_Mapping($classic_array = null)
+    function __construct($classic_array = null)
     {
         $this->keys = array();
         $this->values = array();
@@ -274,7 +274,7 @@ class Auth_OpenID_Mapping {
  * @package OpenID
  */
 class Auth_OpenID_NamespaceMap {
-    function Auth_OpenID_NamespaceMap()
+    function __construct()
     {
         $this->alias_to_namespace = new Auth_OpenID_Mapping();
         $this->namespace_to_alias = new Auth_OpenID_Mapping();
@@ -414,7 +414,7 @@ class Auth_OpenID_NamespaceMap {
  */
 class Auth_OpenID_Message {
 
-    function Auth_OpenID_Message($openid_namespace = null)
+    function __construct($openid_namespace = null)
     {
         // Create an empty Message
         $this->allowed_openid_namespaces = array(

--- a/lib/php-openid/Auth/OpenID/PAPE.php
+++ b/lib/php-openid/Auth/OpenID/PAPE.php
@@ -37,7 +37,7 @@ class Auth_OpenID_PAPE_Request extends Auth_OpenID_Extension {
     var $ns_alias = 'pape';
     var $ns_uri = Auth_OpenID_PAPE_NS_URI;
 
-    function Auth_OpenID_PAPE_Request($preferred_auth_policies=null,
+    function __construct($preferred_auth_policies=null,
                                       $max_auth_age=null)
     {
         if ($preferred_auth_policies === null) {
@@ -161,7 +161,7 @@ class Auth_OpenID_PAPE_Response extends Auth_OpenID_Extension {
     var $ns_alias = 'pape';
     var $ns_uri = Auth_OpenID_PAPE_NS_URI;
 
-    function Auth_OpenID_PAPE_Response($auth_policies=null, $auth_time=null,
+    function __construct($auth_policies=null, $auth_time=null,
                                        $nist_auth_level=null)
     {
         if ($auth_policies) {

--- a/lib/php-openid/Auth/OpenID/Parse.php
+++ b/lib/php-openid/Auth/OpenID/Parse.php
@@ -108,7 +108,7 @@ class Auth_OpenID_Parse {
     var $_open_tag_expr = "<%s\b";
     var $_close_tag_expr = "<((\/%s\b)|(%s[^>\/]*\/))>";
 
-    function Auth_OpenID_Parse()
+    function __construct()
     {
         $this->_link_find = sprintf("/<link\b(?!:)([^>]*)(?!<)>/%s",
                                     $this->_re_flags);

--- a/lib/php-openid/Auth/OpenID/PredisStore.php
+++ b/lib/php-openid/Auth/OpenID/PredisStore.php
@@ -45,7 +45,7 @@ class Auth_OpenID_PredisStore extends Auth_OpenID_OpenIDStore {
      * @param \Predis\Client $redis  Predis client object
      * @param string         $prefix Prefix for all keys stored to the Redis
      */
-    function Auth_OpenID_PredisStore(\Predis\Client $redis, $prefix = '')
+    function __construct(\Predis\Client $redis, $prefix = '')
     {
         $this->prefix = $prefix;
         $this->redis = $redis;

--- a/lib/php-openid/Auth/OpenID/SQLStore.php
+++ b/lib/php-openid/Auth/OpenID/SQLStore.php
@@ -75,7 +75,7 @@ class Auth_OpenID_SQLStore extends Auth_OpenID_OpenIDStore {
      * the name of the table used for storing nonces.  The default
      * value is 'oid_nonces'.
      */
-    function Auth_OpenID_SQLStore($connection,
+    function __construct($connection,
                                   $associations_table = null,
                                   $nonces_table = null)
     {

--- a/lib/php-openid/Auth/OpenID/SReg.php
+++ b/lib/php-openid/Auth/OpenID/SReg.php
@@ -418,7 +418,7 @@ class Auth_OpenID_SRegResponse extends Auth_OpenID_SRegBase {
 
     var $ns_alias = 'sreg';
 
-    function Auth_OpenID_SRegResponse($data=null,
+    function __construct($data=null,
                                       $sreg_ns_uri=Auth_OpenID_SREG_NS_URI)
     {
         if ($data === null) {

--- a/lib/php-openid/Auth/OpenID/Server.php
+++ b/lib/php-openid/Auth/OpenID/Server.php
@@ -148,7 +148,7 @@ class Auth_OpenID_ServerError {
     /**
      * @access private
      */
-    function Auth_OpenID_ServerError($message = null, $text = null,
+    function __construct($message = null, $text = null,
                                      $reference = null, $contact = null)
     {
         $this->message = $message;
@@ -292,10 +292,10 @@ class Auth_OpenID_ServerError {
  * @package OpenID
  */
 class Auth_OpenID_NoReturnToError extends Auth_OpenID_ServerError {
-    function Auth_OpenID_NoReturnToError($message = null,
+    function __construct($message = null,
                                          $text = "No return_to URL available")
     {
-        parent::Auth_OpenID_ServerError($message, $text);
+        parent::__construct($message, $text);
     }
 
     function toString()
@@ -310,10 +310,10 @@ class Auth_OpenID_NoReturnToError extends Auth_OpenID_ServerError {
  * @package OpenID
  */
 class Auth_OpenID_MalformedReturnURL extends Auth_OpenID_ServerError {
-    function Auth_OpenID_MalformedReturnURL($message, $return_to)
+    function __construct($message, $return_to)
     {
         $this->return_to = $return_to;
-        parent::Auth_OpenID_ServerError($message, "malformed return_to URL");
+        parent::__construct($message, "malformed return_to URL");
     }
 }
 
@@ -323,10 +323,10 @@ class Auth_OpenID_MalformedReturnURL extends Auth_OpenID_ServerError {
  * @package OpenID
  */
 class Auth_OpenID_MalformedTrustRoot extends Auth_OpenID_ServerError {
-    function Auth_OpenID_MalformedTrustRoot($message = null,
+    function __construct($message = null,
                                             $text = "Malformed trust root")
     {
-        parent::Auth_OpenID_ServerError($message, $text);
+        parent::__construct($message, $text);
     }
 
     function toString()
@@ -353,7 +353,7 @@ class Auth_OpenID_CheckAuthRequest extends Auth_OpenID_Request {
     var $mode = "check_authentication";
     var $invalidate_handle = null;
 
-    function Auth_OpenID_CheckAuthRequest($assoc_handle, $signed,
+    function __construct($assoc_handle, $signed,
                                           $invalidate_handle = null)
     {
         $this->assoc_handle = $assoc_handle;
@@ -463,7 +463,7 @@ class Auth_OpenID_DiffieHellmanSHA1ServerSession {
     var $allowed_assoc_types = array('HMAC-SHA1');
     var $hash_func = 'Auth_OpenID_SHA1';
 
-    function Auth_OpenID_DiffieHellmanSHA1ServerSession($dh, $consumer_pubkey)
+    function __construct($dh, $consumer_pubkey)
     {
         $this->dh = $dh;
         $this->consumer_pubkey = $consumer_pubkey;
@@ -590,7 +590,7 @@ class Auth_OpenID_AssociateRequest extends Auth_OpenID_Request {
           'DH-SHA256' => 'Auth_OpenID_DiffieHellmanSHA256ServerSession');
     }
 
-    function Auth_OpenID_AssociateRequest($session, $assoc_type)
+    function __construct($session, $assoc_type)
     {
         $this->session = $session;
         $this->namespace = Auth_OpenID_OPENID2_NS;
@@ -763,7 +763,7 @@ class Auth_OpenID_CheckIDRequest extends Auth_OpenID_Request {
         }
     }
 
-    function Auth_OpenID_CheckIDRequest($identity, $return_to,
+    function __construct($identity, $return_to,
                                         $trust_root = null, $immediate = false,
                                         $assoc_handle = null, $server = null,
                                         $claimed_id = null)
@@ -1184,7 +1184,7 @@ class Auth_OpenID_CheckIDRequest extends Auth_OpenID_Request {
  */
 class Auth_OpenID_ServerResponse {
 
-    function Auth_OpenID_ServerResponse($request)
+    function __construct($request)
     {
         $this->request = $request;
         $this->fields = new Auth_OpenID_Message($this->request->namespace);
@@ -1271,7 +1271,7 @@ class Auth_OpenID_WebResponse {
     var $code = AUTH_OPENID_HTTP_OK;
     var $body = "";
 
-    function Auth_OpenID_WebResponse($code = null, $headers = null,
+    function __construct($code = null, $headers = null,
                                      $body = null)
     {
         if ($code) {
@@ -1311,7 +1311,7 @@ class Auth_OpenID_Signatory {
     /**
      * Create a new signatory using a given store.
      */
-    function Auth_OpenID_Signatory($store)
+    function __construct($store)
     {
         // assert store is not None
         $this->store = $store;
@@ -1483,7 +1483,7 @@ class Auth_OpenID_Encoder {
  */
 class Auth_OpenID_SigningEncoder extends Auth_OpenID_Encoder {
 
-    function Auth_OpenID_SigningEncoder($signatory)
+    function __construct($signatory)
     {
         $this->signatory = $signatory;
     }
@@ -1521,7 +1521,7 @@ class Auth_OpenID_SigningEncoder extends Auth_OpenID_Encoder {
  */
 class Auth_OpenID_Decoder {
 
-    function Auth_OpenID_Decoder($server)
+    function __construct($server)
     {
         $this->server = $server;
 
@@ -1604,9 +1604,11 @@ class Auth_OpenID_Decoder {
  * @package OpenID
  */
 class Auth_OpenID_EncodingError {
-    function Auth_OpenID_EncodingError($response)
+    function __construct($response = null)
     {
-        $this->response = $response;
+        if ($response !== null) {
+            $this->response = $response;
+        }
     }
 }
 
@@ -1616,7 +1618,7 @@ class Auth_OpenID_EncodingError {
  * @package OpenID
  */
 class Auth_OpenID_AlreadySigned extends Auth_OpenID_EncodingError {
-    // This response is already signed.
+
 }
 
 /**
@@ -1626,10 +1628,10 @@ class Auth_OpenID_AlreadySigned extends Auth_OpenID_EncodingError {
  * @package OpenID
  */
 class Auth_OpenID_UntrustedReturnURL extends Auth_OpenID_ServerError {
-    function Auth_OpenID_UntrustedReturnURL($message, $return_to,
+    function __construct($message, $return_to,
                                             $trust_root)
     {
-        parent::Auth_OpenID_ServerError($message, "Untrusted return_to URL");
+        parent::__construct($message, "Untrusted return_to URL");
         $this->return_to = $return_to;
         $this->trust_root = $trust_root;
     }
@@ -1679,7 +1681,7 @@ class Auth_OpenID_UntrustedReturnURL extends Auth_OpenID_ServerError {
  * @package OpenID
  */
 class Auth_OpenID_Server {
-    function Auth_OpenID_Server($store, $op_endpoint=null)
+    function __construct($store, $op_endpoint=null)
     {
         $this->store = $store;
         $this->signatory = new Auth_OpenID_Signatory($this->store);

--- a/lib/php-openid/Auth/OpenID/ServerRequest.php
+++ b/lib/php-openid/Auth/OpenID/ServerRequest.php
@@ -28,7 +28,7 @@ require_once "Auth/OpenID.php";
  * @package OpenID
  */
 class Auth_OpenID_ServerRequest {
-    function Auth_OpenID_ServerRequest()
+    function __construct()
     {
         $this->mode = null;
     }

--- a/lib/php-openid/Auth/OpenID/URINorm.php
+++ b/lib/php-openid/Auth/OpenID/URINorm.php
@@ -93,7 +93,17 @@ function Auth_OpenID_pct_encoded_replace_unreserved($mo)
 
 function Auth_OpenID_pct_encoded_replace($mo)
 {
-    return chr(intval($mo[1], 16));
+    $code = intval($mo[1], 16);
+
+    // Prevent request splitting by ignoring newline and space characters
+    if($code === 0xA || $code === 0xD || $code === ord(' '))
+    {
+        return $mo[0];
+    }
+    else
+    {
+        return chr($code);
+    }
 }
 
 function Auth_OpenID_remove_dot_segments($path)

--- a/lib/php-openid/Auth/Yadis/HTTPFetcher.php
+++ b/lib/php-openid/Auth/Yadis/HTTPFetcher.php
@@ -23,7 +23,7 @@ define('Auth_OpenID_USER_AGENT',
        'php-openid/'.Auth_OpenID_VERSION.' (php/'.phpversion().')');
 
 class Auth_Yadis_HTTPResponse {
-    function Auth_Yadis_HTTPResponse($final_url = null, $status = null,
+    function __construct($final_url = null, $status = null,
                                          $headers = null, $body = null)
     {
         $this->final_url = $final_url;

--- a/lib/php-openid/Auth/Yadis/Manager.php
+++ b/lib/php-openid/Auth/Yadis/Manager.php
@@ -280,7 +280,7 @@ class Auth_Yadis_Manager {
      *
      * @access private
      */
-    function Auth_Yadis_Manager($starting_url, $yadis_url,
+    function __construct($starting_url, $yadis_url,
                                     $services, $session_key)
     {
         // The URL that was used to initiate the Yadis protocol
@@ -387,7 +387,7 @@ class Auth_Yadis_Discovery {
      * @param string $session_key_suffix The optional session key
      * suffix override.
      */
-    function Auth_Yadis_Discovery($session, $url,
+    function __construct($session, $url,
                                       $session_key_suffix = null)
     {
         /// Initialize a discovery object

--- a/lib/php-openid/Auth/Yadis/ParanoidHTTPFetcher.php
+++ b/lib/php-openid/Auth/Yadis/ParanoidHTTPFetcher.php
@@ -27,7 +27,7 @@ require_once "Auth/OpenID.php";
  * @package OpenID
  */
 class Auth_Yadis_ParanoidHTTPFetcher extends Auth_Yadis_HTTPFetcher {
-    function Auth_Yadis_ParanoidHTTPFetcher()
+    function __construct()
     {
         $this->reset();
     }
@@ -154,18 +154,18 @@ class Auth_Yadis_ParanoidHTTPFetcher extends Auth_Yadis_HTTPFetcher {
                 curl_setopt($c, CURLOPT_PROXY, Auth_OpenID_HTTP_PROXY);
             }
 
-			// <TYPO3-specific>
-			if ($GLOBALS['TYPO3_CONF_VARS']['SYS']['curlProxyServer']) {
-				curl_setopt($c, CURLOPT_PROXY, $GLOBALS['TYPO3_CONF_VARS']['SYS']['curlProxyServer']);
+            // <TYPO3-specific>
+            if ($GLOBALS['TYPO3_CONF_VARS']['SYS']['curlProxyServer']) {
+                curl_setopt($c, CURLOPT_PROXY, $GLOBALS['TYPO3_CONF_VARS']['SYS']['curlProxyServer']);
 
-				if ($GLOBALS['TYPO3_CONF_VARS']['SYS']['curlProxyTunnel']) {
-					curl_setopt($c, CURLOPT_HTTPPROXYTUNNEL, $GLOBALS['TYPO3_CONF_VARS']['SYS']['curlProxyTunnel']);
-				}
-				if ($GLOBALS['TYPO3_CONF_VARS']['SYS']['curlProxyUserPass']) {
-					curl_setopt($c, CURLOPT_PROXYUSERPWD, $GLOBALS['TYPO3_CONF_VARS']['SYS']['curlProxyUserPass']);
-				}
-			}
-			// </TYPO3-specific>
+                if ($GLOBALS['TYPO3_CONF_VARS']['SYS']['curlProxyTunnel']) {
+                    curl_setopt($c, CURLOPT_HTTPPROXYTUNNEL, $GLOBALS['TYPO3_CONF_VARS']['SYS']['curlProxyTunnel']);
+                }
+                if ($GLOBALS['TYPO3_CONF_VARS']['SYS']['curlProxyUserPass']) {
+                    curl_setopt($c, CURLOPT_PROXYUSERPWD, $GLOBALS['TYPO3_CONF_VARS']['SYS']['curlProxyUserPass']);
+                }
+            }
+            // </TYPO3-specific>
 
             curl_exec($c);
 
@@ -230,18 +230,18 @@ class Auth_Yadis_ParanoidHTTPFetcher extends Auth_Yadis_HTTPFetcher {
             curl_setopt($c, CURLOPT_PROXY, Auth_OpenID_HTTP_PROXY);
         }
 
-		// <TYPO3-specific>
-		if ($GLOBALS['TYPO3_CONF_VARS']['SYS']['curlProxyServer']) {
-			curl_setopt($c, CURLOPT_PROXY, $GLOBALS['TYPO3_CONF_VARS']['SYS']['curlProxyServer']);
+        // <TYPO3-specific>
+        if ($GLOBALS['TYPO3_CONF_VARS']['SYS']['curlProxyServer']) {
+            curl_setopt($c, CURLOPT_PROXY, $GLOBALS['TYPO3_CONF_VARS']['SYS']['curlProxyServer']);
 
-			if ($GLOBALS['TYPO3_CONF_VARS']['SYS']['curlProxyTunnel']) {
-				curl_setopt($c, CURLOPT_HTTPPROXYTUNNEL, $GLOBALS['TYPO3_CONF_VARS']['SYS']['curlProxyTunnel']);
-			}
-			if ($GLOBALS['TYPO3_CONF_VARS']['SYS']['curlProxyUserPass']) {
-				curl_setopt($c, CURLOPT_PROXYUSERPWD, $GLOBALS['TYPO3_CONF_VARS']['SYS']['curlProxyUserPass']);
-			}
-		}
-		// </TYPO3-specific>
+            if ($GLOBALS['TYPO3_CONF_VARS']['SYS']['curlProxyTunnel']) {
+                curl_setopt($c, CURLOPT_HTTPPROXYTUNNEL, $GLOBALS['TYPO3_CONF_VARS']['SYS']['curlProxyTunnel']);
+            }
+            if ($GLOBALS['TYPO3_CONF_VARS']['SYS']['curlProxyUserPass']) {
+                curl_setopt($c, CURLOPT_PROXYUSERPWD, $GLOBALS['TYPO3_CONF_VARS']['SYS']['curlProxyUserPass']);
+            }
+        }
+        // </TYPO3-specific>
 
         curl_setopt($c, CURLOPT_POST, true);
         curl_setopt($c, CURLOPT_POSTFIELDS, $body);

--- a/lib/php-openid/Auth/Yadis/ParseHTML.php
+++ b/lib/php-openid/Auth/Yadis/ParseHTML.php
@@ -43,7 +43,7 @@ class Auth_Yadis_ParseHTML {
      */
     var $_attr_find = '\b([-\w]+)=(".*?"|\'.*?\'|.+?)[\/\s>]';
 
-    function Auth_Yadis_ParseHTML()
+    function __construct()
     {
         $this->_attr_find = sprintf("/%s/%s",
                                     $this->_attr_find,

--- a/lib/php-openid/Auth/Yadis/XML.php
+++ b/lib/php-openid/Auth/Yadis/XML.php
@@ -134,7 +134,7 @@ class Auth_Yadis_XMLParser {
  * @package OpenID
  */
 class Auth_Yadis_domxml extends Auth_Yadis_XMLParser {
-    function Auth_Yadis_domxml()
+    function __construct()
     {
         $this->xml = null;
         $this->doc = null;
@@ -217,7 +217,7 @@ class Auth_Yadis_domxml extends Auth_Yadis_XMLParser {
  * @package OpenID
  */
 class Auth_Yadis_dom extends Auth_Yadis_XMLParser {
-    function Auth_Yadis_dom()
+    function __construct()
     {
         $this->xml = null;
         $this->doc = null;

--- a/lib/php-openid/Auth/Yadis/XRDS.php
+++ b/lib/php-openid/Auth/Yadis/XRDS.php
@@ -85,7 +85,7 @@ class Auth_Yadis_Service {
     /**
      * Creates an empty service object.
      */
-    function Auth_Yadis_Service()
+    function __construct()
     {
         $this->element = null;
         $this->parser = null;
@@ -255,7 +255,7 @@ class Auth_Yadis_XRDS {
      * Instantiate a Auth_Yadis_XRDS object.  Requires an XPath
      * instance which has been used to parse a valid XRDS document.
      */
-    function Auth_Yadis_XRDS($xmlParser, $xrdNodes)
+    function __construct($xmlParser, $xrdNodes)
     {
         $this->parser = $xmlParser;
         $this->xrdNode = $xrdNodes[count($xrdNodes) - 1];

--- a/lib/php-openid/Auth/Yadis/XRIRes.php
+++ b/lib/php-openid/Auth/Yadis/XRIRes.php
@@ -8,7 +8,7 @@ require_once 'Auth/Yadis/XRDS.php';
 require_once 'Auth/Yadis/XRI.php';
 
 class Auth_Yadis_ProxyResolver {
-    function Auth_Yadis_ProxyResolver($fetcher, $proxy_url = null)
+    function __construct($fetcher, $proxy_url = null)
     {
         $this->fetcher = $fetcher;
         $this->proxy_url = $proxy_url;

--- a/lib/php-openid/Auth/Yadis/Yadis.php
+++ b/lib/php-openid/Auth/Yadis/Yadis.php
@@ -68,7 +68,7 @@ class Auth_Yadis_DiscoveryResult {
     // Did the discovery fail miserably?
     var $failed = false;
 
-    function Auth_Yadis_DiscoveryResult($request_uri)
+    function __construct($request_uri)
     {
         // Initialize the state of the object
         // sets all attributes to None except the request_uri


### PR DESCRIPTION
Using this with more and more PHP7 instances the constructor
errors are spamming all error logs. With the latest commit from
the php-openid repository those should be fixed:
* https://github.com/openid/php-openid/commit/d8ef0dba1fa378fc22fe6d423f9423febb2d996d

There is also a security patch within the current php-openid master.

Would be nice if in a distant future we can use the php-openid composer package, instead of packaging the lib inside the TYPO3 extension.