### PR TITLE
[BUGFIX] Remove unused typo3 option 'curlUse'

### DIFF
--- a/Classes/OpenidService.php
+++ b/Classes/OpenidService.php
@@ -76,20 +76,6 @@ class OpenidService extends AbstractService
     protected static $openIDLibrariesIncluded = false;
 
     /**
-     * Constructs the OpenID authentication service.
-     */
-    public function __construct()
-    {
-        // Auth_Yadis_Yadis::getHTTPFetcher() will use a cURL fetcher if the functionality
-        // is available in PHP, however the TYPO3 setting is not considered here:
-        if (!defined('Auth_Yadis_CURL_OVERRIDE')) {
-            if (!$GLOBALS['TYPO3_CONF_VARS']['SYS']['curlUse']) {
-                define('Auth_Yadis_CURL_OVERRIDE', true);
-            }
-        }
-    }
-
-    /**
      * Checks if service is available,. In case of this service we check that
      * prerequisites for "PHP OpenID" libraries are fulfilled:
      * - GMP or BCMATH PHP extensions are installed and functional


### PR DESCRIPTION
Remove the unused TYPO3_CONF_VARS entry 'curlUse'.

Otherwise the 'Auth_Yadis_ParanoidHTTPFetcher' never will be used, even if curl is available.