### PR TITLE
[TASK] Remove database creation options

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -44,4 +44,4 @@ CREATE TABLE tx_openid_nonce_store (
 	PRIMARY KEY (uid),
 	UNIQUE KEY nonce (server_url(255),tstamp,salt),
 	KEY crdate (crdate)
-) DEFAULT CHARSET = utf8 COLLATE utf8_general_ci ENGINE=InnoDB;
+) ENGINE=InnoDB;


### PR DESCRIPTION
Remove database creation options that cause failures with TYPO3 v10 SQL parser

Resolves: #30